### PR TITLE
feat(vulns): add `CVE-2020-8553`

### DIFF
--- a/vulns/CVE-2020-8553.json
+++ b/vulns/CVE-2020-8553.json
@@ -1,0 +1,44 @@
+{
+  "id": "CVE-2020-8553",
+  "modified": "2020-02-19T19:00:32Z",
+  "published": "2020-02-19T19:00:32Z",
+  "summary": "ingress-nginx auth-type basic annotation vulnerability",
+  "details": "The Kubernetes ingress-nginx component prior to version 0.28.0 allows a user with the ability to create namespaces and to read and create ingress objects to overwrite the password file of another ingress which uses nginx.ingress.kubernetes.io/auth-type: basic and which has a hyphenated namespace or secret name.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "/ingress-nginx"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:N"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.28.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/126818"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2020-8553"
+    }
+  ]
+}

--- a/vulns/CVE-2020-8553.json
+++ b/vulns/CVE-2020-8553.json
@@ -8,7 +8,7 @@
     {
       "package": {
         "ecosystem": "kubernetes",
-        "name": "/ingress-nginx"
+        "name": "k8s.io/ingress-nginx"
       },
       "severity": [
         {


### PR DESCRIPTION
## Description
This PR adds vulns/CVE-2020-8553.json
The file was created using [create_pr.sh script](https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/scripts/create_pr.sh) and updated manually using information from [security issue](https://github.com/kubernetes/kubernetes/issues/126818)