### PR TITLE
feat(vulns): add `CVE-2021-25742`

### DIFF
--- a/vulns/CVE-2021-25742.json
+++ b/vulns/CVE-2021-25742.json
@@ -1,0 +1,50 @@
+{
+  "id": "CVE-2021-25742",
+  "modified": "2021-10-21T16:08:21Z",
+  "published": "2021-10-21T16:08:21Z",
+  "summary": "Ingress-nginx custom snippets allows retrieval of ingress-nginx serviceaccount token and secrets across all namespaces",
+  "details": "A security issue was discovered in ingress-nginx where a user that can create or update ingress objects can use the custom snippets feature to obtain all secrets in the cluster.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "/kubernetes ingress-nginx"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0.49.0"
+            },
+            {
+              "last_affected": "0.49.0"
+            },
+            {
+              "introduced": "1.0.0"
+            },
+            {
+              "last_affected": "1.0.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/126811"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2021-25742"
+    }
+  ]
+}

--- a/vulns/CVE-2021-25742.json
+++ b/vulns/CVE-2021-25742.json
@@ -8,7 +8,7 @@
     {
       "package": {
         "ecosystem": "kubernetes",
-        "name": "/kubernetes ingress-nginx"
+        "name": "k8s.io/ingress-nginx"
       },
       "severity": [
         {
@@ -21,16 +21,7 @@
           "type": "SEMVER",
           "events": [
             {
-              "introduced": "0.49.0"
-            },
-            {
-              "last_affected": "0.49.0"
-            },
-            {
-              "introduced": "1.0.0"
-            },
-            {
-              "last_affected": "1.0.0"
+              "introduced": "0"
             }
           ]
         }


### PR DESCRIPTION
## Description
This PR adds vulns/CVE-2021-25742.json
The file was created using [create_pr.sh script](https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/scripts/create_pr.sh) and updated manually using information from https://github.com/kubernetes/kubernetes/issues/126811