### PR TITLE
feat(vulns): add `CVE-2024-10220`

### DIFF
--- a/vulns/CVE-2024-10220.json
+++ b/vulns/CVE-2024-10220.json
@@ -1,0 +1,56 @@
+{
+  "id": "CVE-2024-10220",
+  "modified": "2024-11-20T15:30:44Z",
+  "published": "2024-11-20T15:30:44Z",
+  "summary": "Arbitrary command execution through gitRepo volume",
+  "details": "The Kubernetes kubelet component allows arbitrary command execution via specially crafted gitRepo volumes.This issue affects kubelet: through 1.28.11, from 1.29.0 through 1.29.6, from 1.30.0 through 1.30.2.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "k8s.io/kubelet"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.28.11"
+            },
+            {
+              "introduced": "1.29.0"
+            },
+            {
+              "last_affected": "1.29.6"
+            },
+            {
+              "introduced": "1.30.0"
+            },
+            {
+              "last_affected": "1.30.2"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/128885"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2024-10220"
+    }
+  ]
+}

--- a/vulns/CVE-2024-10220.json
+++ b/vulns/CVE-2024-10220.json
@@ -24,19 +24,19 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.28.11"
+              "fixed": "1.28.12"
             },
             {
               "introduced": "1.29.0"
             },
             {
-              "last_affected": "1.29.6"
+              "fixed": "1.29.7"
             },
             {
               "introduced": "1.30.0"
             },
             {
-              "last_affected": "1.30.2"
+              "fixed": "1.30.3"
             }
           ]
         }


### PR DESCRIPTION
## Description
This PR adds vulns/CVE-2024-10220.json
The file was created using [create_pr.sh script](https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/scripts/create_pr.sh) and updated manually using information from https://github.com/kubernetes/kubernetes/issues/128885