### PR TITLE
feat(vulns): add `CVE-2024-9486`

### DIFF
--- a/vulns/CVE-2024-9486.json
+++ b/vulns/CVE-2024-9486.json
@@ -1,0 +1,44 @@
+{
+  "id": "CVE-2024-9486",
+  "modified": "2024-10-11T18:04:31Z",
+  "published": "2024-10-11T18:04:31Z",
+  "summary": "VM images built with Image Builder and Proxmox provider use default credentials",
+  "details": "A security issue was discovered in the Kubernetes Image Builder versions \u003c= v0.1.37 where default credentials are enabled during the image build process. Virtual machine images built using the Proxmox provider do not disable these default credentials, and nodes using the resulting images may be accessible via these default credentials. The credentials can be used to gain root access. Kubernetes clusters are only affected if their nodes use VM images created via the Image Builder project with its Proxmox provider.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "/image builder"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "0.1.37"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/128006"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2024-9486"
+    }
+  ]
+}

--- a/vulns/CVE-2024-9486.json
+++ b/vulns/CVE-2024-9486.json
@@ -8,7 +8,7 @@
     {
       "package": {
         "ecosystem": "kubernetes",
-        "name": "k8s.io/image-builder"
+        "name": "github.com/kubernetes-csi/image-builder"
       },
       "severity": [
         {

--- a/vulns/CVE-2024-9486.json
+++ b/vulns/CVE-2024-9486.json
@@ -8,7 +8,7 @@
     {
       "package": {
         "ecosystem": "kubernetes",
-        "name": "/image builder"
+        "name": "k8s.io/image-builder"
       },
       "severity": [
         {
@@ -24,7 +24,7 @@
               "introduced": "0"
             },
             {
-              "last_affected": "0.1.37"
+              "fixed": "0.1.38"
             }
           ]
         }


### PR DESCRIPTION
## Description
This PR adds vulns/CVE-2024-9486.json
The file was created using [create_pr.sh script](https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/scripts/create_pr.sh) and updated manually using information from https://github.com/kubernetes/kubernetes/issues/128006