### PR TITLE
feat(vulns): add `CVE-2025-0426`

### DIFF
--- a/vulns/CVE-2025-0426.json
+++ b/vulns/CVE-2025-0426.json
@@ -1,0 +1,56 @@
+{
+  "id": "CVE-2025-0426",
+  "modified": "2025-02-06T20:03:44Z",
+  "published": "2025-02-06T20:03:44Z",
+  "summary": "Node Denial of Service via kubelet Checkpoint API",
+  "details": "A security issue was discovered in Kubernetes where a large number of container checkpoint requests made to the unauthenticated kubelet read-only HTTP endpoint may cause a Node Denial of Service by filling the Node's disk.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "k8s.io/kubelet"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "1.32.0"
+            },
+            {
+              "last_affected": "1.32.1"
+            },
+            {
+              "introduced": "1.31.0"
+            },
+            {
+              "last_affected": "1.31.5"
+            },
+            {
+              "introduced": "1.30.0"
+            },
+            {
+              "last_affected": "1.30.9"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/130016"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2025-0426"
+    }
+  ]
+}

--- a/vulns/CVE-2025-0426.json
+++ b/vulns/CVE-2025-0426.json
@@ -21,22 +21,28 @@
           "type": "SEMVER",
           "events": [
             {
-              "introduced": "1.32.0"
+              "introduced": "0"
             },
             {
-              "last_affected": "1.32.1"
-            },
-            {
-              "introduced": "1.31.0"
-            },
-            {
-              "last_affected": "1.31.5"
+              "fixed": "1.29.14"
             },
             {
               "introduced": "1.30.0"
             },
             {
-              "last_affected": "1.30.9"
+              "fixed": "1.30.10"
+            },
+            {
+              "introduced": "1.31.0"
+            },
+            {
+              "fixed": "1.31.6"
+            },
+            {
+              "introduced": "1.32.0"
+            },
+            {
+              "fixed": "1.32.2"
             }
           ]
         }


### PR DESCRIPTION
## Description
This PR adds vulns/CVE-2025-0426.json
The file was created using [create_pr.sh script](https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/scripts/create_pr.sh) and updated manually using information from https://github.com/kubernetes/kubernetes/issues/130016