### PR TITLE
feat(vulns): add `CVE-2025-1097`

### DIFF
--- a/vulns/CVE-2025-1097.json
+++ b/vulns/CVE-2025-1097.json
@@ -1,0 +1,50 @@
+{
+  "id": "CVE-2025-1097",
+  "modified": "2025-03-23T17:38:49Z",
+  "published": "2025-03-23T17:38:49Z",
+  "summary": "configuration injection via unsanitized auth-tls-match-cn annotation",
+  "details": "A security issue was discovered in  ingress-nginx https://github.com/kubernetes/ingress-nginx  where the `auth-tls-match-cn` Ingress annotation can be used to inject configuration into nginx. This can lead to arbitrary code execution in the context of the ingress-nginx controller, and disclosure of Secrets accessible to the controller. (Note that in the default installation, the controller can access all Secrets cluster-wide.)",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "/ingress-nginx"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.11.4"
+            },
+            {
+              "introduced": "1.12.0"
+            },
+            {
+              "last_affected": "1.12.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/131007"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2025-1097"
+    }
+  ]
+}

--- a/vulns/CVE-2025-1097.json
+++ b/vulns/CVE-2025-1097.json
@@ -8,7 +8,7 @@
     {
       "package": {
         "ecosystem": "kubernetes",
-        "name": "/ingress-nginx"
+        "name": "k8s.io/ingress-nginx"
       },
       "severity": [
         {
@@ -24,13 +24,13 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.11.4"
+              "fixed": "1.11.5"
             },
             {
               "introduced": "1.12.0"
             },
             {
-              "last_affected": "1.12.0"
+              "fixed": "1.12.1"
             }
           ]
         }


### PR DESCRIPTION
## Description
This PR adds vulns/CVE-2025-1097.json
The file was created using [create_pr.sh script](https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/scripts/create_pr.sh) and updated manually using information from https://github.com/kubernetes/kubernetes/issues/131007