### PR TITLE
feat(vulns): add `CVE-2025-1767`

### DIFF
--- a/vulns/CVE-2025-1767.json
+++ b/vulns/CVE-2025-1767.json
@@ -1,0 +1,44 @@
+{
+  "id": "CVE-2025-1767",
+  "modified": "2025-03-13T16:08:20Z",
+  "published": "2025-03-13T16:08:20Z",
+  "summary": "GitRepo Volume Inadvertent Local Repository Access",
+  "details": "This CVE only affects Kubernetes clusters that utilize the in-tree gitRepo volume to clone git repositories from other pods within the same node. Since the in-tree gitRepo volume feature has been deprecated and will not receive security updates upstream, any cluster still using this feature remains vulnerable.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "k8s.io/kubelet"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:N"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "\u003c=v1.32.2"
+            },
+            {
+              "last_affected": "\u003c=v1.32.2"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/130786"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2025-1767"
+    }
+  ]
+}

--- a/vulns/CVE-2025-1767.json
+++ b/vulns/CVE-2025-1767.json
@@ -8,7 +8,7 @@
     {
       "package": {
         "ecosystem": "kubernetes",
-        "name": "k8s.io/kubelet"
+        "name": "k8s.io/kubernetes"
       },
       "severity": [
         {
@@ -21,10 +21,7 @@
           "type": "SEMVER",
           "events": [
             {
-              "introduced": "\u003c=v1.32.2"
-            },
-            {
-              "last_affected": "\u003c=v1.32.2"
+              "introduced": "0"
             }
           ]
         }


### PR DESCRIPTION
## Description
This PR adds vulns/CVE-2025-1767.json
The file was created using [create_pr.sh script](https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/scripts/create_pr.sh) and updated manually using information from https://github.com/kubernetes/kubernetes/issues/130786