### PR TITLE
feat(vulns): add `CVE-2025-1974`

### DIFF
--- a/vulns/CVE-2025-1974.json
+++ b/vulns/CVE-2025-1974.json
@@ -1,0 +1,50 @@
+{
+  "id": "CVE-2025-1974",
+  "modified": "2025-03-23T17:38:57Z",
+  "published": "2025-03-23T17:38:57Z",
+  "summary": "ingress-nginx admission controller RCE escalation",
+  "details": "A security issue was discovered in Kubernetes where under certain conditions, an unauthenticated attacker with access to the pod network can achieve arbitrary code execution in the context of the ingress-nginx controller. This can lead to disclosure of Secrets accessible to the controller. (Note that in the default installation, the controller can access all Secrets cluster-wide.)",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "/ingress-nginx"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.11.4"
+            },
+            {
+              "introduced": "1.12.0"
+            },
+            {
+              "last_affected": "1.12.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/131009"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2025-1974"
+    }
+  ]
+}

--- a/vulns/CVE-2025-1974.json
+++ b/vulns/CVE-2025-1974.json
@@ -8,7 +8,7 @@
     {
       "package": {
         "ecosystem": "kubernetes",
-        "name": "/ingress-nginx"
+        "name": "k8s.io/ingress-nginx"
       },
       "severity": [
         {
@@ -24,13 +24,13 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.11.4"
+              "fixed": "1.11.5"
             },
             {
               "introduced": "1.12.0"
             },
             {
-              "last_affected": "1.12.0"
+              "fixed": "1.12.1"
             }
           ]
         }


### PR DESCRIPTION
## Description
This PR adds vulns/CVE-2025-1974.json
The file was created using [create_pr.sh script](https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/scripts/create_pr.sh) and updated manually using information from https://github.com/kubernetes/kubernetes/issues/131009