### PR TITLE
feat(vulns): add `CVE-2025-24513`

### DIFF
--- a/vulns/CVE-2025-24513.json
+++ b/vulns/CVE-2025-24513.json
@@ -1,0 +1,50 @@
+{
+  "id": "CVE-2025-24513",
+  "modified": "2025-03-23T17:38:28Z",
+  "published": "2025-03-23T17:38:28Z",
+  "summary": "auth secret file path traversal vulnerability",
+  "details": "A security issue was discovered in  ingress-nginx https://github.com/kubernetes/ingress-nginx  where attacker-provided data are included in a filename by the ingress-nginx Admission Controller feature, resulting in directory traversal within the container. This could result in denial of service, or when combined with other vulnerabilities, limited disclosure of Secret objects from the cluster.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "/ingress-nginx"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:L"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "last_affected": "1.11.4"
+            },
+            {
+              "introduced": "1.12.0"
+            },
+            {
+              "last_affected": "1.12.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/131005"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2025-24513"
+    }
+  ]
+}

--- a/vulns/CVE-2025-24513.json
+++ b/vulns/CVE-2025-24513.json
@@ -8,7 +8,7 @@
     {
       "package": {
         "ecosystem": "kubernetes",
-        "name": "/ingress-nginx"
+        "name": "k8s.io/ingress-nginx"
       },
       "severity": [
         {
@@ -24,13 +24,13 @@
               "introduced": "0"
             },
             {
-              "last_affected": "1.11.4"
+              "fixed": "1.11.5"
             },
             {
               "introduced": "1.12.0"
             },
             {
-              "last_affected": "1.12.0"
+              "fixed": "1.12.1"
             }
           ]
         }


### PR DESCRIPTION
## Description
This PR adds vulns/CVE-2025-24513.json
The file was created using [create_pr.sh script](https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/scripts/create_pr.sh) and updated manually using information from https://github.com/kubernetes/kubernetes/issues/131005