### PR TITLE
feat(vulns): add `CVE-2021-25748`

### DIFF
--- a/vulns/CVE-2021-25748.json
+++ b/vulns/CVE-2021-25748.json
@@ -1,0 +1,44 @@
+{
+  "id": "CVE-2021-25748",
+  "modified": "2022-06-10T16:01:41Z",
+  "published": "2022-06-10T16:01:41Z",
+  "summary": "Ingress-nginx `path` sanitization can be bypassed with newline character",
+  "details": "A security issue was discovered in ingress-nginx where a user that can create or update ingress objects can use a newline character to bypass the sanitization of the `spec.rules[].http.paths[].path` field of an Ingress object (in the `networking.k8s.io` or `extensions` API group) to obtain the credentials of the ingress-nginx controller. In the default configuration, that credential has access to all secrets in the cluster.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "/kubernetes ingress-nginx"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "1.2.0"
+            },
+            {
+              "fixed": "1.2.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/126814"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2021-25748"
+    }
+  ]
+}

--- a/vulns/CVE-2021-25748.json
+++ b/vulns/CVE-2021-25748.json
@@ -8,7 +8,7 @@
     {
       "package": {
         "ecosystem": "kubernetes",
-        "name": "/kubernetes ingress-nginx"
+        "name": "k8s.io/ingress-nginx"
       },
       "severity": [
         {
@@ -21,7 +21,7 @@
           "type": "SEMVER",
           "events": [
             {
-              "introduced": "1.2.0"
+              "introduced": "0"
             },
             {
               "fixed": "1.2.1"


### PR DESCRIPTION
## Description
This PR adds vulns/CVE-2021-25748.json
The file was created using [create_pr.sh script](https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/scripts/create_pr.sh) and updated manually using information from https://github.com/kubernetes/kubernetes/issues/126814