### PR TITLE
Update CVE-2021-25740, CVE-2020-8561, CVE-2020-8562

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # For git diff
 

--- a/vulns/CVE-2020-8561.json
+++ b/vulns/CVE-2020-8561.json
@@ -1,0 +1,31 @@
+{
+  "id": "CVE-2020-8561",
+  "modified": "2021-09-01T20:18:50Z",
+  "published": "2021-09-01T20:18:50Z",
+  "summary": "Webhook redirect in kube-apiserver",
+  "details": "A security issue was discovered in Kubernetes where actors that control the responses of MutatingWebhookConfiguration or ValidatingWebhookConfiguration requests are able to redirect kube-apiserver requests to private networks of the apiserver. If that user can view kube-apiserver logs when the log level is set to 10, they can view the redirected responses and headers in the logs.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "k8s.io/apiserver"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:C/C:L/I:N/A:N"
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/104720"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2020-8561"
+    }
+  ]
+}

--- a/vulns/CVE-2020-8562.json
+++ b/vulns/CVE-2020-8562.json
@@ -1,0 +1,31 @@
+{
+  "id": "CVE-2020-8562",
+  "modified": "2021-04-26T19:18:04Z",
+  "published": "2021-04-26T19:18:04Z",
+  "summary": "Bypass of Kubernetes API Server proxy TOCTOU",
+  "details": "As mitigations to a report from 2019 and CVE-2020-8555, Kubernetes attempts to prevent proxied connections from accessing link-local or localhost networks when making user-driven connections to Services, Pods, Nodes, or StorageClass service providers. As part of this mitigation Kubernetes does a DNS name resolution check and validates that response IPs are not in the link-local (169.254.0.0/16) or localhost (127.0.0.0/8) range. Kubernetes then performs a second DNS resolution without validation for the actual connection. If a non-standard DNS server returns different non-cached responses, a user may be able to bypass the proxy IP restriction and access private networks on the control plane.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "k8s.io/kubernetes"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:L/I:N/A:N"
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/101493"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2020-8562"
+    }
+  ]
+}

--- a/vulns/CVE-2021-25740.json
+++ b/vulns/CVE-2021-25740.json
@@ -1,0 +1,31 @@
+{
+  "id": "CVE-2021-25740",
+  "modified": "2021-07-14T03:30:07Z",
+  "published": "2021-07-14T03:30:07Z",
+  "summary": "Endpoint \u0026 EndpointSlice permissions allow cross-Namespace forwarding",
+  "details": "A security issue was discovered with Kubernetes that could enable users to send network traffic to locations they would otherwise not have access to via a confused deputy attack.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "k8s.io/kubectl"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N"
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/103675"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2021-25740"
+    }
+  ]
+}

--- a/vulns/CVE-2026-3288.json
+++ b/vulns/CVE-2026-3288.json
@@ -1,0 +1,56 @@
+{
+  "id": "CVE-2026-3288",
+  "modified": "2026-03-09T04:29:33Z",
+  "published": "2026-03-09T04:29:33Z",
+  "summary": "ingress-nginx rewrite-target nginx configuration injection",
+  "details": "A security issue was discovered in ingress-nginx where the `nginx.ingress.kubernetes.io/rewrite-target` Ingress annotation can be used to inject configuration into nginx. This can lead to arbitrary code execution in the context of the ingress-nginx controller, and disclosure of Secrets accessible to the controller. (Note that in the default installation, the controller can access all Secrets cluster-wide.)",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "/ingress-nginx"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.13.8"
+            },
+            {
+              "introduced": "1.14.0"
+            },
+            {
+              "fixed": "1.14.4"
+            },
+            {
+              "introduced": "1.15.0"
+            },
+            {
+              "fixed": "1.15.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/137560"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2026-3288"
+    }
+  ]
+}

--- a/vulns/CVE-2026-3864.json
+++ b/vulns/CVE-2026-3864.json
@@ -1,0 +1,44 @@
+{
+  "id": "CVE-2026-3864",
+  "modified": "2026-03-17T05:54:49Z",
+  "published": "2026-03-17T05:54:49Z",
+  "summary": "CSI Driver for NFS path traversal via subDir may delete unintended directories on the NFS server",
+  "details": "A vulnerability was discovered in the Kubernetes CSI Driver for NFS where the subDir parameter in volume identifiers was insufficiently validated. Attackers with the ability to create PersistentVolumes referencing the NFS CSI driver could craft volume identifiers containing path traversal sequences (../). During volume deletion or cleanup operations, the driver could operate on unintended directories outside the intended managed path within the NFS export. This may lead to deletion or modification of directories on the NFS server.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "/csi driver for nfs"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:H/A:H"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.13.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/137797"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2026-3864"
+    }
+  ]
+}

--- a/vulns/CVE-2026-4342.json
+++ b/vulns/CVE-2026-4342.json
@@ -1,0 +1,56 @@
+{
+  "id": "CVE-2026-4342",
+  "modified": "2026-03-19T14:32:54Z",
+  "published": "2026-03-19T14:32:54Z",
+  "summary": "ingress-nginx comment-based nginx configuration injection",
+  "details": "A security issue was discovered in ingress-nginx where a combination of Ingress annotations can be used to inject configuration into nginx. This can lead to arbitrary code execution in the context of the ingress-nginx controller, and disclosure of Secrets accessible to the controller. (Note that in the default installation, the controller can access all Secrets cluster-wide.)",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "/ingress-nginx"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.13.9"
+            },
+            {
+              "introduced": "1.14.0"
+            },
+            {
+              "fixed": "1.14.5"
+            },
+            {
+              "introduced": "1.15.0"
+            },
+            {
+              "fixed": "1.15.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/137893"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2026-4342"
+    }
+  ]
+}


### PR DESCRIPTION
Also adds CVE-2026-3288, CVE-2026-3864, CVE-2026-4342

```
pj900915@GJ0FQY17FY cve-feed-osv % check-jsonschema --schemafile schema.json vulns/CVE-2020-8561.json
ok -- validation done
pj900915@GJ0FQY17FY cve-feed-osv % check-jsonschema --schemafile schema.json vulns/CVE-2020-8562.json
ok -- validation done
pj900915@GJ0FQY17FY cve-feed-osv % check-jsonschema --schemafile schema.json vulns/CVE-2021-25740.json
ok -- validation done
pj900915@GJ0FQY17FY cve-feed-osv % check-jsonschema --schemafile schema.json vulns/CVE-2026-3288.json 
ok -- validation done
pj900915@GJ0FQY17FY cve-feed-osv % check-jsonschema --schemafile schema.json vulns/CVE-2026-3864.json     
ok -- validation done
pj900915@GJ0FQY17FY cve-feed-osv % check-jsonschema --schemafile schema.json vulns/CVE-2026-4342.json
ok -- validation done
```