### PR TITLE
fix(vulns/CVE-2026-*): Amend ranges to avoid overlapping

### DIFF
--- a/vulns/CVE-2026-1580.json
+++ b/vulns/CVE-2026-1580.json
@@ -27,7 +27,7 @@
               "fixed": "1.13.7"
             },
             {
-              "introduced": "0"
+              "introduced": "1.14.0"
             },
             {
               "fixed": "1.14.3"

--- a/vulns/CVE-2026-24512.json
+++ b/vulns/CVE-2026-24512.json
@@ -27,7 +27,7 @@
               "fixed": "1.13.7"
             },
             {
-              "introduced": "0"
+              "introduced": "1.14.0"
             },
             {
               "fixed": "1.14.3"

--- a/vulns/CVE-2026-24513.json
+++ b/vulns/CVE-2026-24513.json
@@ -27,7 +27,7 @@
               "fixed": "1.13.7"
             },
             {
-              "introduced": "0"
+              "introduced": "1.14.0"
             },
             {
               "fixed": "1.14.3"

--- a/vulns/CVE-2026-24514.json
+++ b/vulns/CVE-2026-24514.json
@@ -27,7 +27,7 @@
               "fixed": "1.13.7"
             },
             {
-              "introduced": "0"
+              "introduced": "1.14.0"
             },
             {
               "fixed": "1.14.3"


### PR DESCRIPTION
According to the OSV schema, [semver ranges should not overlap](https://ossf.github.io/osv-schema/#affectedrangestype-field):

> Ranges listed with type SEMVER should not overlap: since SEMVER is a strict linear ordering, it is always possible to simplify to non-overlapping ranges.

Github advisories have the right ranges:

* [CVE-2026-24512](https://github.com/advisories/GHSA-jx8c-56mg-h6vp)
* [CVE-2026-24513](https://github.com/advisories/GHSA-4g2f-xcph-2335)
* [CVE-2026-24514](https://github.com/advisories/GHSA-2pf9-vr92-6h3v)
* [CVE-2026-1580](https://github.com/advisories/GHSA-9h3p-52vh-959w)