### PR TITLE
Update OSV with correct version ranges

### DIFF
--- a/vulns/CVE-2021-25742.json
+++ b/vulns/CVE-2021-25742.json
@@ -22,6 +22,15 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "last_affected": "0.49.0"
+            },
+            {
+              "introduced": "1.0.0"
+            },
+            {
+              "last_affected": "1.0.0"
             }
           ]
         }

--- a/vulns/CVE-2023-5043.json
+++ b/vulns/CVE-2023-5043.json
@@ -22,6 +22,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "1.9.0"
             }
           ]
         }

--- a/vulns/CVE-2023-5044.json
+++ b/vulns/CVE-2023-5044.json
@@ -22,6 +22,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "1.9.0"
             }
           ]
         }

--- a/vulns/CVE-2025-1767.json
+++ b/vulns/CVE-2025-1767.json
@@ -22,6 +22,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "last_affected": "1.32.2"
             }
           ]
         }


### PR DESCRIPTION
  - CVE-2023-5044 — added fixed: "1.9.0" (MITRE: version 0, lessThan 1.9.0)
  - CVE-2023-5043 — added fixed: "1.9.0" (MITRE: version 0, lessThan 1.9.0)
  - CVE-2025-1767 — added last_affected: "1.32.2" (MITRE: <=v1.32.2)
  - CVE-2021-25742 — added two non-overlapping segments: last_affected: "0.49.0" then introduced: "1.0.0" / last_affected: "1.0.0"